### PR TITLE
fix(Interactables): update Interactables namespace to latest

### DIFF
--- a/Runtime/SharedResources/Scripts/PseudoBodyProcessor.cs
+++ b/Runtime/SharedResources/Scripts/PseudoBodyProcessor.cs
@@ -6,7 +6,7 @@
     using Malimbe.XmlDocumentationAttribute;
     using System;
     using System.Collections.Generic;
-    using Tilia.Interactions.Interactables;
+    using Tilia.Interactions.Interactables.Interactables;
     using Tilia.Interactions.Interactables.Interactors;
     using UnityEngine;
     using Zinnia.Cast;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dependencies": {
         "io.extendreality.zinnia.unity": "1.19.0",
         "io.extendreality.tilia.mutators.collisionignorer.unity": "1.1.11",
-        "io.extendreality.tilia.interactions.interactables.unity": "1.8.1"
+        "io.extendreality.tilia.interactions.interactables.unity": "1.9.0"
     },
     "files": [
         "*.md",


### PR DESCRIPTION
The Interactables namespace changed in version 1.9.0 of the
Interactables package, so it has been updated accordingly.