### PR TITLE
fix(Processor): ensure interactable ungrab is done correctly - fixes #80

### DIFF
--- a/Documentation/API/PseudoBodyFacade.md
+++ b/Documentation/API/PseudoBodyFacade.md
@@ -112,7 +112,7 @@ public UnityEvent StillDiverged
 
 #### IgnoredInteractors
 
-A collection of interactors to exclude from physics collision checks.
+A collection of Interactors to exclude from physics collision checks.
 
 ##### Declaration
 
@@ -224,7 +224,7 @@ public virtual void ListenToRigidbodyMovement()
 
 ##### Remarks
 
-This method needs to be called right before or right after applying any form of movement to the rigidbody while the body is grounded, i.e. in the same frame and before [Process()] is called.
+This method needs to be called right before or right after applying any form of movement to the Rigidbody while the body is grounded, i.e. in the same frame and before [Process()] is called.
 
 #### OnAfterIgnoredInteractorsChange()
 
@@ -296,7 +296,7 @@ protected virtual void OnIgnoredInteractorAdded(InteractorFacade interactor)
 
 | Type | Name | Description |
 | --- | --- | --- |
-| InteractorFacade | interactor | The interactor to ignore collisions from. |
+| InteractorFacade | interactor | The Interactor to ignore collisions from. |
 
 #### OnIgnoredInteractorRemoved(InteractorFacade)
 
@@ -312,7 +312,7 @@ protected virtual void OnIgnoredInteractorRemoved(InteractorFacade interactor)
 
 | Type | Name | Description |
 | --- | --- | --- |
-| InteractorFacade | interactor | The interactor to resume collisions with. |
+| InteractorFacade | interactor | The Interactor to resume collisions with. |
 
 #### SetSourceDivergenceThresholdX(Single)
 

--- a/Documentation/API/PseudoBodyProcessor.DivergenceState.md
+++ b/Documentation/API/PseudoBodyProcessor.DivergenceState.md
@@ -9,7 +9,7 @@
 
 # Enum PseudoBodyProcessor.DivergenceState
 
-The divergence state of the psuedo body.
+The divergence state of the pseudo body.
 
 ##### Namespace
 
@@ -26,8 +26,8 @@ public enum DivergenceState
 | Name | Description |
 | --- | --- |
 | BecameConverged | the pseudo body is no longer diverged. |
-| BecameDiverged | the psuedo body has become diverged. |
-| NotDiverged | The psuedo body is not diverged. |
+| BecameDiverged | the pseudo body has become diverged. |
+| NotDiverged | The pseudo body is not diverged. |
 | StillDiverged | the pseudo body is still diverged. |
 
 [Tilia.Trackers.PseudoBody]: README.md

--- a/Documentation/API/PseudoBodyProcessor.md
+++ b/Documentation/API/PseudoBodyProcessor.md
@@ -108,7 +108,7 @@ protected readonly HashSet<Collider> ignoredColliders
 
 #### ignoreInteractorCollisions
 
-Stores the routine for ignoring interactor collisions.
+Stores the routine for ignoring Interactor collisions.
 
 ##### Declaration
 
@@ -210,7 +210,7 @@ public CollisionIgnorer CollisionsToIgnore { get; protected set; }
 
 #### CurrentDivergenceState
 
-The current divergence state of the psuedo body.
+The current divergence state of the pseudo body.
 
 ##### Declaration
 
@@ -372,7 +372,7 @@ protected virtual void EmitIsGroundedChangedEvent(bool isCharacterControllerGrou
 
 #### GetDivergenceState()
 
-Determines the divergence state of the psuedo body.
+Determines the divergence state of the pseudo body.
 
 ##### Declaration
 
@@ -388,7 +388,7 @@ protected virtual PseudoBodyProcessor.DivergenceState GetDivergenceState()
 
 #### IgnoreInteractorGrabbedCollision(InteractableFacade)
 
-Ignores the interactable grabbed by the interactor.
+Ignores the Interactable grabbed by the Interactor.
 
 ##### Declaration
 
@@ -400,11 +400,11 @@ protected virtual void IgnoreInteractorGrabbedCollision(InteractableFacade inter
 
 | Type | Name | Description |
 | --- | --- | --- |
-| InteractableFacade | interactable | The interactable to ignore. |
+| InteractableFacade | interactable | The Interactable to ignore. |
 
 #### IgnoreInteractorsCollisions(InteractorFacade)
 
-Ignores all of the colliders on the interactor collection.
+Ignores all of the colliders on the Interactor collection.
 
 ##### Declaration
 
@@ -492,7 +492,7 @@ protected virtual void RememberCurrentPositions()
 
 #### ResumeInteractorsCollisions(InteractorFacade)
 
-Resumes all of the colliders on the interactor collection.
+Resumes all of the colliders on the Interactor collection.
 
 ##### Declaration
 
@@ -508,7 +508,7 @@ public virtual void ResumeInteractorsCollisions(InteractorFacade interactor)
 
 #### ResumeInteractorUngrabbedCollision(InteractableFacade)
 
-Resumes the interactable ungrabbed by the interactor.
+Resumes the Interactable ungrabbed by the Interactor.
 
 ##### Declaration
 
@@ -520,7 +520,7 @@ protected virtual void ResumeInteractorUngrabbedCollision(InteractableFacade int
 
 | Type | Name | Description |
 | --- | --- | --- |
-| InteractableFacade | interactable | The interactable to resume. |
+| InteractableFacade | interactable | The Interactable to resume. |
 
 #### SolveBodyCollisions()
 

--- a/Documentation/API/README.md
+++ b/Documentation/API/README.md
@@ -16,7 +16,7 @@ Sets up the PseudoBody prefab based on the provided user settings and implements
 
 #### [PseudoBodyProcessor.DivergenceState]
 
-The divergence state of the psuedo body.
+The divergence state of the pseudo body.
 
 #### [PseudoBodyProcessor.MovementInterest]
 

--- a/Runtime/SharedResources/Scripts/PseudoBodyFacade.cs
+++ b/Runtime/SharedResources/Scripts/PseudoBodyFacade.cs
@@ -47,7 +47,7 @@
 
         #region Interaction Settings
         /// <summary>
-        /// A collection of interactors to exclude from physics collision checks.
+        /// A collection of Interactors to exclude from physics collision checks.
         /// </summary>
         [Serialized]
         [field: Header("Interaction Settings"), DocumentedByXml]
@@ -145,7 +145,7 @@
         /// Sets the source of truth for movement to come from <see cref="PseudoBodyProcessor.PhysicsBody"/> until <see cref="PseudoBodyProcessor.Character"/> hits the ground, then <see cref="PseudoBodyProcessor.Character"/> is the new source of truth.
         /// </summary>
         /// <remarks>
-        /// This method needs to be called right before or right after applying any form of movement to the rigidbody while the body is grounded, i.e. in the same frame and before <see cref="PseudoBodyProcessor.Process"/> is called.
+        /// This method needs to be called right before or right after applying any form of movement to the <see cref="Rigidbody"/> while the body is grounded, i.e. in the same frame and before <see cref="PseudoBodyProcessor.Process"/> is called.
         /// </remarks>
         public virtual void ListenToRigidbodyMovement()
         {
@@ -188,7 +188,7 @@
         /// <summary>
         /// Processes when a new <see cref="InteractorFacade"/> is added to the ignored collection.
         /// </summary>
-        /// <param name="interactor">The interactor to ignore collisions from.</param>
+        /// <param name="interactor">The Interactor to ignore collisions from.</param>
         protected virtual void OnIgnoredInteractorAdded(InteractorFacade interactor)
         {
             Processor.IgnoreInteractorsCollisions(interactor);
@@ -197,7 +197,7 @@
         /// <summary>
         /// Processes when a new <see cref="InteractorFacade"/> is removed from the ignored collection.
         /// </summary>
-        /// <param name="interactor">The interactor to resume collisions with.</param>
+        /// <param name="interactor">The Interactor to resume collisions with.</param>
         protected virtual void OnIgnoredInteractorRemoved(InteractorFacade interactor)
         {
             Processor.ResumeInteractorsCollisions(interactor);

--- a/Runtime/SharedResources/Scripts/PseudoBodyProcessor.cs
+++ b/Runtime/SharedResources/Scripts/PseudoBodyProcessor.cs
@@ -7,6 +7,7 @@
     using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.Linq;
     using Tilia.Interactions.Interactables.Interactables;
     using Tilia.Interactions.Interactables.Interactors;
     using UnityEngine;
@@ -47,16 +48,16 @@
         }
 
         /// <summary>
-        /// The divergence state of the psuedo body.
+        /// The divergence state of the pseudo body.
         /// </summary>
         public enum DivergenceState
         {
             /// <summary>
-            /// The psuedo body is not diverged.
+            /// The pseudo body is not diverged.
             /// </summary>
             NotDiverged,
             /// <summary>
-            /// the psuedo body has become diverged.
+            /// the pseudo body has become diverged.
             /// </summary>
             BecameDiverged,
             /// <summary>
@@ -110,7 +111,7 @@
         /// </summary>
         public MovementInterest Interest { get; set; } = MovementInterest.CharacterControllerUntilAirborne;
         /// <summary>
-        /// The current divergence state of the psuedo body.
+        /// The current divergence state of the pseudo body.
         /// </summary>
         public DivergenceState CurrentDivergenceState => GetDivergenceState();
         /// <summary>
@@ -147,7 +148,7 @@
         /// </summary>
         protected int rigidbodySetFrameCount;
         /// <summary>
-        /// Stores the routine for ignoring interactor collisions.
+        /// Stores the routine for ignoring Interactor collisions.
         /// </summary>
         protected Coroutine ignoreInteractorCollisions;
         /// <summary>
@@ -186,7 +187,7 @@
 
             Vector3 previousCharacterControllerPosition;
 
-            // Handle walking down stairs/slopes and physics affecting the Rigidbody in general.
+            // Handle walking down stairs/slopes and physics affecting the RigidBody in general.
             Vector3 rigidbodyPhysicsMovement = PhysicsBody.position - previousRigidbodyPosition;
             if (Interest == MovementInterest.Rigidbody || Interest == MovementInterest.RigidbodyUntilGrounded)
             {
@@ -209,7 +210,7 @@
 
             bool isGrounded = CheckIfCharacterControllerIsGrounded();
 
-            // Allow moving the Rigidbody via physics.
+            // Allow moving the RigidBody via physics.
             if (Interest == MovementInterest.CharacterControllerUntilAirborne && !isGrounded)
             {
                 Interest = MovementInterest.RigidbodyUntilGrounded;
@@ -298,7 +299,7 @@
         }
 
         /// <summary>
-        /// Ignores all of the colliders on the interactor collection.
+        /// Ignores all of the colliders on the Interactor collection.
         /// </summary>
         public virtual void IgnoreInteractorsCollisions(InteractorFacade interactor)
         {
@@ -308,7 +309,7 @@
         }
 
         /// <summary>
-        /// Resumes all of the colliders on the interactor collection.
+        /// Resumes all of the colliders on the Interactor collection.
         /// </summary>
         public virtual void ResumeInteractorsCollisions(InteractorFacade interactor)
         {
@@ -340,21 +341,24 @@
         }
 
         /// <summary>
-        /// Ignores the interactable grabbed by the interactor.
+        /// Ignores the Interactable grabbed by the Interactor.
         /// </summary>
-        /// <param name="interactable">The interactable to ignore.</param>
+        /// <param name="interactable">The Interactable to ignore.</param>
         protected virtual void IgnoreInteractorGrabbedCollision(InteractableFacade interactable)
         {
             CollisionsToIgnore.RunWhenActiveAndEnabled(() => CollisionsToIgnore.Targets.AddUnique(interactable.gameObject));
         }
 
         /// <summary>
-        /// Resumes the interactable ungrabbed by the interactor.
+        /// Resumes the Interactable ungrabbed by the Interactor.
         /// </summary>
-        /// <param name="interactable">The interactable to resume.</param>
+        /// <param name="interactable">The Interactable to resume.</param>
         protected virtual void ResumeInteractorUngrabbedCollision(InteractableFacade interactable)
         {
-            CollisionsToIgnore.RunWhenActiveAndEnabled(() => CollisionsToIgnore.Targets.Remove(interactable.gameObject));
+            if (interactable.GrabbingInteractors.Count == 0 || !Facade.IgnoredInteractors.NonSubscribableElements.Intersect(interactable.GrabbingInteractors).Any())
+            {
+                CollisionsToIgnore.RunWhenActiveAndEnabled(() => CollisionsToIgnore.Targets.Remove(interactable.gameObject));
+            }
         }
 
         /// <summary>
@@ -486,7 +490,7 @@
         }
 
         /// <summary>
-        /// Determines the divergence state of the psuedo body.
+        /// Determines the divergence state of the pseudo body.
         /// </summary>
         /// <returns>The divergence state.</returns>
         protected virtual DivergenceState GetDivergenceState()


### PR DESCRIPTION
The ignored interactors ungrab mechanism would cause an issue if
both interactors were grabbing an interactable as this would
successfully ignore the interactable from the pseudobody as expected
but if the secondary interactor ungrabbed then it would remove
the interactable from the ignored collisions meaning the primary
interactor could still collide the interactable with the pseudobody.

This has been fixed by guarding the ungrab mechanism.