### PR TITLE
fix(Processor): use offset scale when calculating height - fixes #54

### DIFF
--- a/Runtime/SharedResources/Scripts/PseudoBodyProcessor.cs
+++ b/Runtime/SharedResources/Scripts/PseudoBodyProcessor.cs
@@ -370,7 +370,7 @@
             Vector3 sourcePosition = Facade.Source.transform.position;
             float height = Facade.Offset == null
                 ? sourcePosition.y
-                : Facade.Offset.transform.InverseTransformPoint(sourcePosition).y;
+                : Facade.Offset.transform.InverseTransformPoint(sourcePosition).y * Facade.Offset.transform.lossyScale.y;
             height -= Character.skinWidth;
 
             // CharacterController enforces a minimum height of twice its radius, so let's match that here.


### PR DESCRIPTION
There was an issue when the offset scale was larger than 1 then the
height calculation would cause the rigidbody position to be set
incorrectly which would infinitely increase the y position of the
character controller. This would cause the target to be flung in the
air. This fix ensures the height is calculated from the offset Y
position but taking into consideration any scaling on the offset.