### PR TITLE
feat(Trackers): allow any GameObject collision to be ignored

### DIFF
--- a/Documentation/API/PseudoBodyFacade.md
+++ b/Documentation/API/PseudoBodyFacade.md
@@ -14,6 +14,7 @@ The public interface for the PseudoBody prefab.
   * [Diverged]
   * [StillDiverged]
 * [Properties]
+  * [IgnoredGameObjects]
   * [IgnoredInteractors]
   * [Interest]
   * [IsCharacterControllerGrounded]
@@ -25,15 +26,10 @@ The public interface for the PseudoBody prefab.
   * [SourceDivergenceThreshold]
   * [SourceThickness]
 * [Methods]
+  * [Awake()]
   * [ListenToRigidbodyMovement()]
-  * [OnAfterIgnoredInteractorsChange()]
   * [OnAfterOffsetChange()]
   * [OnAfterSourceChange()]
-  * [OnBeforeIgnoredInteractorsChange()]
-  * [OnDisable()]
-  * [OnEnable()]
-  * [OnIgnoredInteractorAdded(InteractorFacade)]
-  * [OnIgnoredInteractorRemoved(InteractorFacade)]
   * [SetSourceDivergenceThresholdX(Single)]
   * [SetSourceDivergenceThresholdY(Single)]
   * [SetSourceDivergenceThresholdZ(Single)]
@@ -110,6 +106,16 @@ public UnityEvent StillDiverged
 
 ### Properties
 
+#### IgnoredGameObjects
+
+A GameObject collection to exclude from physics collision checks.
+
+##### Declaration
+
+```
+public GameObjectObservableList IgnoredGameObjects { get; set; }
+```
+
 #### IgnoredInteractors
 
 A collection of Interactors to exclude from physics collision checks.
@@ -117,6 +123,7 @@ A collection of Interactors to exclude from physics collision checks.
 ##### Declaration
 
 ```
+[Obsolete("Use `IgnoredGameObjects` instead.")]
 public InteractorFacadeObservableList IgnoredInteractors { get; set; }
 ```
 
@@ -212,6 +219,14 @@ public float SourceThickness { get; set; }
 
 ### Methods
 
+#### Awake()
+
+##### Declaration
+
+```
+protected virtual void Awake()
+```
+
 #### ListenToRigidbodyMovement()
 
 Sets the source of truth for movement to come from [PhysicsBody] until [Character] hits the ground, then [Character] is the new source of truth.
@@ -225,16 +240,6 @@ public virtual void ListenToRigidbodyMovement()
 ##### Remarks
 
 This method needs to be called right before or right after applying any form of movement to the Rigidbody while the body is grounded, i.e. in the same frame and before [Process()] is called.
-
-#### OnAfterIgnoredInteractorsChange()
-
-Called after [IgnoredInteractors] has been changed.
-
-##### Declaration
-
-```
-protected virtual void OnAfterIgnoredInteractorsChange()
-```
 
 #### OnAfterOffsetChange()
 
@@ -255,64 +260,6 @@ Called after [Source] has been changed.
 ```
 protected virtual void OnAfterSourceChange()
 ```
-
-#### OnBeforeIgnoredInteractorsChange()
-
-Called after [IgnoredInteractors] has been changed.
-
-##### Declaration
-
-```
-protected virtual void OnBeforeIgnoredInteractorsChange()
-```
-
-#### OnDisable()
-
-##### Declaration
-
-```
-protected virtual void OnDisable()
-```
-
-#### OnEnable()
-
-##### Declaration
-
-```
-protected virtual void OnEnable()
-```
-
-#### OnIgnoredInteractorAdded(InteractorFacade)
-
-Processes when a new InteractorFacade is added to the ignored collection.
-
-##### Declaration
-
-```
-protected virtual void OnIgnoredInteractorAdded(InteractorFacade interactor)
-```
-
-##### Parameters
-
-| Type | Name | Description |
-| --- | --- | --- |
-| InteractorFacade | interactor | The Interactor to ignore collisions from. |
-
-#### OnIgnoredInteractorRemoved(InteractorFacade)
-
-Processes when a new InteractorFacade is removed from the ignored collection.
-
-##### Declaration
-
-```
-protected virtual void OnIgnoredInteractorRemoved(InteractorFacade interactor)
-```
-
-##### Parameters
-
-| Type | Name | Description |
-| --- | --- | --- |
-| InteractorFacade | interactor | The Interactor to resume collisions with. |
 
 #### SetSourceDivergenceThresholdX(Single)
 
@@ -388,10 +335,8 @@ If body collisions should be prevented this method needs to be called right befo
 [Character]: PseudoBodyProcessor.md#Tilia_Trackers_PseudoBody_PseudoBodyProcessor_Character
 [Character]: PseudoBodyProcessor.md#Tilia_Trackers_PseudoBody_PseudoBodyProcessor_Character
 [Process()]: PseudoBodyProcessor.md#Tilia_Trackers_PseudoBody_PseudoBodyProcessor_Process
-[IgnoredInteractors]: PseudoBodyFacade.md#IgnoredInteractors
 [Offset]: PseudoBodyFacade.md#Offset
 [Source]: PseudoBodyFacade.md#Source
-[IgnoredInteractors]: PseudoBodyFacade.md#IgnoredInteractors
 [SourceDivergenceThreshold]: PseudoBodyFacade.md#SourceDivergenceThreshold
 [SourceDivergenceThreshold]: PseudoBodyFacade.md#SourceDivergenceThreshold
 [SourceDivergenceThreshold]: PseudoBodyFacade.md#SourceDivergenceThreshold
@@ -405,6 +350,7 @@ If body collisions should be prevented this method needs to be called right befo
 [Diverged]: #Diverged
 [StillDiverged]: #StillDiverged
 [Properties]: #Properties
+[IgnoredGameObjects]: #IgnoredGameObjects
 [IgnoredInteractors]: #IgnoredInteractors
 [Interest]: #Interest
 [IsCharacterControllerGrounded]: #IsCharacterControllerGrounded
@@ -416,15 +362,10 @@ If body collisions should be prevented this method needs to be called right befo
 [SourceDivergenceThreshold]: #SourceDivergenceThreshold
 [SourceThickness]: #SourceThickness
 [Methods]: #Methods
+[Awake()]: #Awake
 [ListenToRigidbodyMovement()]: #ListenToRigidbodyMovement
-[OnAfterIgnoredInteractorsChange()]: #OnAfterIgnoredInteractorsChange
 [OnAfterOffsetChange()]: #OnAfterOffsetChange
 [OnAfterSourceChange()]: #OnAfterSourceChange
-[OnBeforeIgnoredInteractorsChange()]: #OnBeforeIgnoredInteractorsChange
-[OnDisable()]: #OnDisable
-[OnEnable()]: #OnEnable
-[OnIgnoredInteractorAdded(InteractorFacade)]: #OnIgnoredInteractorAddedInteractorFacade
-[OnIgnoredInteractorRemoved(InteractorFacade)]: #OnIgnoredInteractorRemovedInteractorFacade
 [SetSourceDivergenceThresholdX(Single)]: #SetSourceDivergenceThresholdXSingle
 [SetSourceDivergenceThresholdY(Single)]: #SetSourceDivergenceThresholdYSingle
 [SetSourceDivergenceThresholdZ(Single)]: #SetSourceDivergenceThresholdZSingle

--- a/Documentation/API/PseudoBodyProcessor.md
+++ b/Documentation/API/PseudoBodyProcessor.md
@@ -38,7 +38,9 @@ Sets up the PseudoBody prefab based on the provided user settings and implements
   * [ConfigureSourceObjectFollower()]
   * [EmitIsGroundedChangedEvent(Boolean)]
   * [GetDivergenceState()]
+  * [GetGameObjectListFromInteractorFacadeList(IReadOnlyList<InteractorFacade>)]
   * [IgnoreInteractorGrabbedCollision(InteractableFacade)]
+  * [IgnoreInteractorsCollisions(GameObject)]
   * [IgnoreInteractorsCollisions(InteractorFacade)]
   * [MatchCharacterControllerWithSource(Boolean)]
   * [MatchRigidbodyAndColliderWithCharacterController()]
@@ -47,6 +49,7 @@ Sets up the PseudoBody prefab based on the provided user settings and implements
   * [OnEnable()]
   * [Process()]
   * [RememberCurrentPositions()]
+  * [ResumeInteractorsCollisions(GameObject)]
   * [ResumeInteractorsCollisions(InteractorFacade)]
   * [ResumeInteractorUngrabbedCollision(InteractableFacade)]
   * [SolveBodyCollisions()]
@@ -386,6 +389,28 @@ protected virtual PseudoBodyProcessor.DivergenceState GetDivergenceState()
 | --- | --- |
 | [PseudoBodyProcessor.DivergenceState] | The divergence state. |
 
+#### GetGameObjectListFromInteractorFacadeList(IReadOnlyList<InteractorFacade>)
+
+Converts the InteractorFacade collection to a GameObject collection.
+
+##### Declaration
+
+```
+protected virtual IReadOnlyList<GameObject> GetGameObjectListFromInteractorFacadeList(IReadOnlyList<InteractorFacade> interactorList)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Collections.Generic.IReadOnlyList<InteractorFacade\> | interactorList | The list to convert. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Collections.Generic.IReadOnlyList<GameObject\> | The converted list. |
+
 #### IgnoreInteractorGrabbedCollision(InteractableFacade)
 
 Ignores the Interactable grabbed by the Interactor.
@@ -402,6 +427,22 @@ protected virtual void IgnoreInteractorGrabbedCollision(InteractableFacade inter
 | --- | --- | --- |
 | InteractableFacade | interactable | The Interactable to ignore. |
 
+#### IgnoreInteractorsCollisions(GameObject)
+
+Ignores all collisions between any found Interactor and this PsuedoBody.
+
+##### Declaration
+
+```
+public virtual void IgnoreInteractorsCollisions(GameObject ignoredObject)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | ignoredObject | The object to ignore. |
+
 #### IgnoreInteractorsCollisions(InteractorFacade)
 
 Ignores all of the colliders on the Interactor collection.
@@ -409,6 +450,7 @@ Ignores all of the colliders on the Interactor collection.
 ##### Declaration
 
 ```
+[Obsolete("Add `InteractorFacade.gameObject` to `PseudoBodyProcessor.CollisionsToIgnore.Targets` instead.")]
 public virtual void IgnoreInteractorsCollisions(InteractorFacade interactor)
 ```
 
@@ -490,6 +532,22 @@ Updates the previous position variables to remember the current state.
 protected virtual void RememberCurrentPositions()
 ```
 
+#### ResumeInteractorsCollisions(GameObject)
+
+Resumes all collisions between any found Interactor and this PsuedoBody.
+
+##### Declaration
+
+```
+public virtual void ResumeInteractorsCollisions(GameObject ignoredObject)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | ignoredObject | The object being ignored. |
+
 #### ResumeInteractorsCollisions(InteractorFacade)
 
 Resumes all of the colliders on the Interactor collection.
@@ -497,6 +555,7 @@ Resumes all of the colliders on the Interactor collection.
 ##### Declaration
 
 ```
+[Obsolete("Remove `InteractorFacade.gameObject` to `PseudoBodyProcessor.CollisionsToIgnore.Targets` instead.")]
 public virtual void ResumeInteractorsCollisions(InteractorFacade interactor)
 ```
 
@@ -614,7 +673,9 @@ IProcessable
 [ConfigureSourceObjectFollower()]: #ConfigureSourceObjectFollower
 [EmitIsGroundedChangedEvent(Boolean)]: #EmitIsGroundedChangedEventBoolean
 [GetDivergenceState()]: #GetDivergenceState
+[GetGameObjectListFromInteractorFacadeList(IReadOnlyList<InteractorFacade>)]: #GetGameObjectListFromInteractorFacadeListIReadOnlyList<InteractorFacade>
 [IgnoreInteractorGrabbedCollision(InteractableFacade)]: #IgnoreInteractorGrabbedCollisionInteractableFacade
+[IgnoreInteractorsCollisions(GameObject)]: #IgnoreInteractorsCollisionsGameObject
 [IgnoreInteractorsCollisions(InteractorFacade)]: #IgnoreInteractorsCollisionsInteractorFacade
 [MatchCharacterControllerWithSource(Boolean)]: #MatchCharacterControllerWithSourceBoolean
 [MatchRigidbodyAndColliderWithCharacterController()]: #MatchRigidbodyAndColliderWithCharacterController
@@ -623,6 +684,7 @@ IProcessable
 [OnEnable()]: #OnEnable
 [Process()]: #Process
 [RememberCurrentPositions()]: #RememberCurrentPositions
+[ResumeInteractorsCollisions(GameObject)]: #ResumeInteractorsCollisionsGameObject
 [ResumeInteractorsCollisions(InteractorFacade)]: #ResumeInteractorsCollisionsInteractorFacade
 [ResumeInteractorUngrabbedCollision(InteractableFacade)]: #ResumeInteractorUngrabbedCollisionInteractableFacade
 [SolveBodyCollisions()]: #SolveBodyCollisions

--- a/Runtime/Prefabs/Trackers.PseudoBody.prefab
+++ b/Runtime/Prefabs/Trackers.PseudoBody.prefab
@@ -140,6 +140,113 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: de75bfe8037417348b9096302c0d52e8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &2614255107785146916
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5299097616694498908}
+  - component: {fileID: 8680406507566844786}
+  m_Layer: 0
+  m_Name: IgnoredGameObjects
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5299097616694498908
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2614255107785146916}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8676741933201522399}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8680406507566844786
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2614255107785146916}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Found:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  NotFound:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  IsEmpty:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  IsPopulated:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  Populated:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Added:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6936212126056299515}
+        m_MethodName: AddUnique
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Removed:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6936212126056299515}
+        m_MethodName: DoRemove
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Emptied:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  currentIndex: 0
+  elements: []
 --- !u!1 &3594951784783497484
 GameObject:
   m_ObjectHideFlags: 0
@@ -258,6 +365,7 @@ Transform:
   - {fileID: 912379197835606767}
   - {fileID: 7274352695782326568}
   - {fileID: 8231786302581471524}
+  - {fileID: 5299097616694498908}
   m_Father: {fileID: 746484800121047788}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -345,7 +453,13 @@ MonoBehaviour:
   sourceThickness: 0.205
   sourceDivergenceThreshold: {x: 0.01, y: 2, z: 0.01}
   ignoredInteractors: {fileID: 6217799343602961637}
+  ignoredGameObjects: {fileID: 8680406507566844786}
   Diverged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  StillDiverged:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
@@ -377,7 +491,7 @@ GameObject:
   - component: {fileID: 8231786302581471524}
   - component: {fileID: 6217799343602961637}
   m_Layer: 0
-  m_Name: IgnoredInteractors
+  m_Name: '[Deprecated]IgnoredInteractors'
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -439,13 +553,35 @@ MonoBehaviour:
       PublicKeyToken=null
   Added:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 7911366584454133691}
+        m_MethodName: IgnoreInteractorsCollisions
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
     m_TypeName: Tilia.Interactions.Interactables.Interactors.Collection.InteractorFacadeObservableList+UnityEvent,
       Tilia.Interactions.Interactables.Unity.Runtime, Version=0.0.0.0, Culture=neutral,
       PublicKeyToken=null
   Removed:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 7911366584454133691}
+        m_MethodName: ResumeInteractorsCollisions
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
     m_TypeName: Tilia.Interactions.Interactables.Interactors.Collection.InteractorFacadeObservableList+UnityEvent,
       Tilia.Interactions.Interactables.Unity.Runtime, Version=0.0.0.0, Culture=neutral,
       PublicKeyToken=null
@@ -651,6 +787,66 @@ PrefabInstance:
       propertyPath: elements.Array.data[1]
       value: 
       objectReference: {fileID: 1741896628679248129}
+    - target: {fileID: 2308899400092309998, guid: 27357be074b04234fa032891fbbeb20b,
+        type: 3}
+      propertyPath: Added.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2308899400092309998, guid: 27357be074b04234fa032891fbbeb20b,
+        type: 3}
+      propertyPath: Removed.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2308899400092309998, guid: 27357be074b04234fa032891fbbeb20b,
+        type: 3}
+      propertyPath: Added.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2308899400092309998, guid: 27357be074b04234fa032891fbbeb20b,
+        type: 3}
+      propertyPath: Added.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2308899400092309998, guid: 27357be074b04234fa032891fbbeb20b,
+        type: 3}
+      propertyPath: Removed.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2308899400092309998, guid: 27357be074b04234fa032891fbbeb20b,
+        type: 3}
+      propertyPath: Removed.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2308899400092309998, guid: 27357be074b04234fa032891fbbeb20b,
+        type: 3}
+      propertyPath: Added.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 7911366584454133691}
+    - target: {fileID: 2308899400092309998, guid: 27357be074b04234fa032891fbbeb20b,
+        type: 3}
+      propertyPath: Removed.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 7911366584454133691}
+    - target: {fileID: 2308899400092309998, guid: 27357be074b04234fa032891fbbeb20b,
+        type: 3}
+      propertyPath: Added.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: IgnoreInteractorsCollisions
+      objectReference: {fileID: 0}
+    - target: {fileID: 2308899400092309998, guid: 27357be074b04234fa032891fbbeb20b,
+        type: 3}
+      propertyPath: Added.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 2308899400092309998, guid: 27357be074b04234fa032891fbbeb20b,
+        type: 3}
+      propertyPath: Removed.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: ResumeInteractorsCollisions
+      objectReference: {fileID: 0}
+    - target: {fileID: 2308899400092309998, guid: 27357be074b04234fa032891fbbeb20b,
+        type: 3}
+      propertyPath: Removed.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 27357be074b04234fa032891fbbeb20b, type: 3}
 --- !u!4 &912379197835606767 stripped
@@ -669,5 +865,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d28135ccdf6492447b269e0d277b842f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6936212126056299515 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2308899400092309998, guid: 27357be074b04234fa032891fbbeb20b,
+    type: 3}
+  m_PrefabInstance: {fileID: 4632158824555012629}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/Runtime/SharedResources/Scripts/PseudoBodyFacade.cs
+++ b/Runtime/SharedResources/Scripts/PseudoBodyFacade.cs
@@ -4,11 +4,12 @@
     using Malimbe.MemberClearanceMethod;
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;
-    using Tilia.Interactions.Interactables.Interactors;
+    using System;
     using Tilia.Interactions.Interactables.Interactors.Collection;
     using UnityEngine;
     using UnityEngine.Events;
     using Zinnia.Data.Attribute;
+    using Zinnia.Data.Collection.List;
 
     /// <summary>
     /// The public interface for the PseudoBody prefab.
@@ -50,8 +51,15 @@
         /// A collection of Interactors to exclude from physics collision checks.
         /// </summary>
         [Serialized]
-        [field: Header("Interaction Settings"), DocumentedByXml]
+        [field: Header("Interaction Settings"), DocumentedByXml, Restricted]
+        [Obsolete("Use `IgnoredGameObjects` instead.")]
         public InteractorFacadeObservableList IgnoredInteractors { get; set; }
+        /// <summary>
+        /// A <see cref="GameObject"/> collection to exclude from physics collision checks.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public GameObjectObservableList IgnoredGameObjects { get; set; }
         #endregion
 
         #region Body Events
@@ -163,44 +171,14 @@
             Processor.SolveBodyCollisions();
         }
 
-        protected virtual void OnEnable()
+        protected virtual void Awake()
         {
-            if (IgnoredInteractors == null)
+#pragma warning disable 0618
+            if (IgnoredInteractors.NonSubscribableElements.Count > 0)
             {
-                return;
+                Debug.LogWarning("`PsuedoBodyFacade.IgnoredInteractors` list has been deprecated. Use the `PsuedoBodyFacade.IgnoredGameObjects` list instead.", gameObject);
             }
-
-            IgnoredInteractors.Added.AddListener(OnIgnoredInteractorAdded);
-            IgnoredInteractors.Removed.AddListener(OnIgnoredInteractorRemoved);
-        }
-
-        protected virtual void OnDisable()
-        {
-            if (IgnoredInteractors == null)
-            {
-                return;
-            }
-
-            IgnoredInteractors.Added.RemoveListener(OnIgnoredInteractorAdded);
-            IgnoredInteractors.Removed.RemoveListener(OnIgnoredInteractorRemoved);
-        }
-
-        /// <summary>
-        /// Processes when a new <see cref="InteractorFacade"/> is added to the ignored collection.
-        /// </summary>
-        /// <param name="interactor">The Interactor to ignore collisions from.</param>
-        protected virtual void OnIgnoredInteractorAdded(InteractorFacade interactor)
-        {
-            Processor.IgnoreInteractorsCollisions(interactor);
-        }
-
-        /// <summary>
-        /// Processes when a new <see cref="InteractorFacade"/> is removed from the ignored collection.
-        /// </summary>
-        /// <param name="interactor">The Interactor to resume collisions with.</param>
-        protected virtual void OnIgnoredInteractorRemoved(InteractorFacade interactor)
-        {
-            Processor.ResumeInteractorsCollisions(interactor);
+#pragma warning restore 0618
         }
 
         /// <summary>
@@ -219,36 +197,6 @@
         protected virtual void OnAfterOffsetChange()
         {
             Processor.ConfigureOffsetObjectFollower();
-        }
-
-        /// <summary>
-        /// Called after <see cref="IgnoredInteractors"/> has been changed.
-        /// </summary>
-        [CalledBeforeChangeOf(nameof(IgnoredInteractors))]
-        protected virtual void OnBeforeIgnoredInteractorsChange()
-        {
-            if (IgnoredInteractors == null)
-            {
-                return;
-            }
-
-            IgnoredInteractors.Added.RemoveListener(OnIgnoredInteractorAdded);
-            IgnoredInteractors.Removed.RemoveListener(OnIgnoredInteractorRemoved);
-        }
-
-        /// <summary>
-        /// Called after <see cref="IgnoredInteractors"/> has been changed.
-        /// </summary>
-        [CalledAfterChangeOf(nameof(IgnoredInteractors))]
-        protected virtual void OnAfterIgnoredInteractorsChange()
-        {
-            if (IgnoredInteractors == null)
-            {
-                return;
-            }
-
-            IgnoredInteractors.Added.AddListener(OnIgnoredInteractorAdded);
-            IgnoredInteractors.Removed.AddListener(OnIgnoredInteractorRemoved);
         }
     }
 }


### PR DESCRIPTION
Previously, the PsuedoBodyFacade would only allow Interactors to be
directly ignored (with having to add other objects to the internal
Collision Ignorer). The `IgnoredInteractors` property has now been
deprecated and in place is a new `IgnoredGameObjects` property which
can have the Interactors added to as before and it still applies the
same logic on to any grabbed Interactable.

However, now if an Interactable is added to the `IgnoredGameObjects`
property then it will always be ignored whereas previously if the
Interactor in the `IgnoredInteractors` property grabbed and released
an Interactable that was added to the internal Collision Ignorer then
the Interactable would be removed from the Collision Ignorer.

Due to `IgnoredInteractors` being deprecated, this means the option
on the facade is now restricted and the internal list items cannot be
accessed from the PsuedoBodyFacade component in the Unity inspector.

Any items in this list will show a deprecation warning. Going to the
internal `[Deprecated]IgnoredInteractors` GameObject and accessing
the InteractorFacadeObservableList component from there will allow
the deprecated list contents to be removed and then these items can
be manually added to the new `IgnoredGameObjects` property.