### PR TITLE
feat(PseudoBodyProcessor): add option to not update source position

### DIFF
--- a/Documentation/API/PseudoBodyProcessor.md
+++ b/Documentation/API/PseudoBodyProcessor.md
@@ -29,6 +29,7 @@ Sets up the PseudoBody prefab based on the provided user settings and implements
   * [IsDiverged]
   * [PhysicsBody]
   * [RigidbodyCollider]
+  * [UpdateSourcePosition]
 * [Methods]
   * [Awake()]
   * [CheckDivergence()]
@@ -279,6 +280,16 @@ The CapsuleCollider that acts as the physical collider representation of the bod
 
 ```
 public CapsuleCollider RigidbodyCollider { get; protected set; }
+```
+
+#### UpdateSourcePosition
+
+Whether the processor should update the Facade.Source position.
+
+##### Declaration
+
+```
+public bool UpdateSourcePosition { get; set; }
 ```
 
 ### Methods
@@ -664,6 +675,7 @@ IProcessable
 [IsDiverged]: #IsDiverged
 [PhysicsBody]: #PhysicsBody
 [RigidbodyCollider]: #RigidbodyCollider
+[UpdateSourcePosition]: #UpdateSourcePosition
 [Methods]: #Methods
 [Awake()]: #Awake
 [CheckDivergence()]: #CheckDivergence

--- a/Runtime/SharedResources/Scripts/PseudoBodyProcessor.cs
+++ b/Runtime/SharedResources/Scripts/PseudoBodyProcessor.cs
@@ -104,6 +104,12 @@
         [Serialized]
         [field: DocumentedByXml, Restricted]
         public CollisionIgnorer CollisionsToIgnore { get; protected set; }
+        /// <summary>
+        /// Whether the processor should update the <see cref="Facade.Source"/> position.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public bool UpdateSourcePosition { get; set; } = true;
         #endregion
 
         /// <summary>
@@ -182,7 +188,10 @@
                 offsetPosition.y = PhysicsBody.position.y - Character.skinWidth;
 
                 Facade.Offset.transform.position = offsetPosition;
-                Facade.Source.transform.position += offsetPosition - previousPosition;
+                if (UpdateSourcePosition)
+                {
+                    Facade.Source.transform.position += offsetPosition - previousPosition;
+                }
             }
 
             Vector3 previousCharacterControllerPosition;
@@ -198,7 +207,10 @@
                 {
                     Vector3 movement = Character.transform.position - previousCharacterControllerPosition;
                     Facade.Offset.transform.position += movement;
-                    Facade.Source.transform.position += movement;
+                    if (UpdateSourcePosition)
+                    {
+                        Facade.Source.transform.position += movement;
+                    }
                 }
             }
 
@@ -272,7 +284,20 @@
             }
 
             float newDistance = difference.magnitude - minimumDistanceToColliders;
-            (Facade.Offset == null ? Facade.Source : Facade.Offset).transform.position -= difference.normalized * newDistance;
+
+            Vector3 newPosition = difference.normalized * newDistance;
+            if (Facade.Offset == null)
+            {
+                if (UpdateSourcePosition)
+                {
+                    Facade.Source.transform.position -= newPosition;
+                }
+            }
+            else
+            {
+                Facade.Offset.transform.position -= newPosition;
+            }
+
             Process();
         }
 


### PR DESCRIPTION
There may be occasions where the Facade.Source position does not want
to be updated when the processor runs. There is not always a need for
the source to update.