### PR TITLE
feat(Facade): add snap to source meethod

### DIFF
--- a/Documentation/API/PseudoBodyFacade.md
+++ b/Documentation/API/PseudoBodyFacade.md
@@ -35,6 +35,7 @@ The public interface for the PseudoBody prefab.
   * [SetSourceDivergenceThresholdX(Single)]
   * [SetSourceDivergenceThresholdY(Single)]
   * [SetSourceDivergenceThresholdZ(Single)]
+  * [SnapToSource()]
   * [SolveBodyCollisions()]
 
 ## Details
@@ -331,6 +332,16 @@ public virtual void SetSourceDivergenceThresholdZ(float value)
 | --- | --- | --- |
 | System.Single | value | The value to set to. |
 
+#### SnapToSource()
+
+Snaps the Processor.Character to the [Source] position.
+
+##### Declaration
+
+```
+public virtual void SnapToSource()
+```
+
 #### SolveBodyCollisions()
 
 Solves body collisions by not moving the body in case it can't go to its current position.
@@ -364,6 +375,7 @@ If body collisions should be prevented this method needs to be called right befo
 [SourceDivergenceThreshold]: PseudoBodyFacade.md#SourceDivergenceThreshold
 [SourceDivergenceThreshold]: PseudoBodyFacade.md#SourceDivergenceThreshold
 [SourceDivergenceThreshold]: PseudoBodyFacade.md#SourceDivergenceThreshold
+[Source]: PseudoBodyFacade.md#Source
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
@@ -395,4 +407,5 @@ If body collisions should be prevented this method needs to be called right befo
 [SetSourceDivergenceThresholdX(Single)]: #SetSourceDivergenceThresholdXSingle
 [SetSourceDivergenceThresholdY(Single)]: #SetSourceDivergenceThresholdYSingle
 [SetSourceDivergenceThresholdZ(Single)]: #SetSourceDivergenceThresholdZSingle
+[SnapToSource()]: #SnapToSource
 [SolveBodyCollisions()]: #SolveBodyCollisions

--- a/Documentation/API/PseudoBodyProcessor.md
+++ b/Documentation/API/PseudoBodyProcessor.md
@@ -10,6 +10,7 @@ Sets up the PseudoBody prefab based on the provided user settings and implements
 * [Fields]
   * [checkDivergedAtEndOfFrameRoutine]
   * [collisionResolutionMovement]
+  * [doSnapToSource]
   * [ignoredColliders]
   * [ignoreInteractorCollisions]
   * [offsetObjectFollower]
@@ -53,6 +54,8 @@ Sets up the PseudoBody prefab based on the provided user settings and implements
   * [ResumeInteractorsCollisions(GameObject)]
   * [ResumeInteractorsCollisions(InteractorFacade)]
   * [ResumeInteractorUngrabbedCollision(InteractableFacade)]
+  * [SnapDependentsToSource()]
+  * [SnapToSource()]
   * [SolveBodyCollisions()]
   * [StopCheckDivergenceAtEndOfFrameRoutine()]
 * [Implements]
@@ -75,7 +78,7 @@ IProcessable
 ##### Syntax
 
 ```
-public class PseudoBodyProcessor : MonoBehaviour, IProcessable
+public class PseudoBodyProcessor : MonoBehaviour
 ```
 
 ### Fields
@@ -98,6 +101,16 @@ Movement to apply to [Character] to resolve collisions.
 
 ```
 protected static readonly Vector3 collisionResolutionMovement
+```
+
+#### doSnapToSource
+
+Whether to snap the dependents to the Facade.Source without any divergent checking.
+
+##### Declaration
+
+```
+protected bool doSnapToSource
 ```
 
 #### ignoredColliders
@@ -592,6 +605,26 @@ protected virtual void ResumeInteractorUngrabbedCollision(InteractableFacade int
 | --- | --- | --- |
 | InteractableFacade | interactable | The Interactable to resume. |
 
+#### SnapDependentsToSource()
+
+Snaps the CharacterController and the [PhysicsBody] to the Facade.Source.
+
+##### Declaration
+
+```
+protected virtual void SnapDependentsToSource()
+```
+
+#### SnapToSource()
+
+Snaps the [Character] to the Facade.Source position.
+
+##### Declaration
+
+```
+public virtual void SnapToSource()
+```
+
 #### SolveBodyCollisions()
 
 Solves body collisions by not moving the body in case it can't go to its current position.
@@ -650,12 +683,15 @@ IProcessable
 [Character]: PseudoBodyProcessor.md#Character
 [Interest]: PseudoBodyProcessor.md#Interest
 [Source]: PseudoBodyFacade.md#Tilia_Trackers_PseudoBody_PseudoBodyFacade_Source
+[PhysicsBody]: PseudoBodyProcessor.md#PhysicsBody
+[Character]: PseudoBodyProcessor.md#Character
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
 [Fields]: #Fields
 [checkDivergedAtEndOfFrameRoutine]: #checkDivergedAtEndOfFrameRoutine
 [collisionResolutionMovement]: #collisionResolutionMovement
+[doSnapToSource]: #doSnapToSource
 [ignoredColliders]: #ignoredColliders
 [ignoreInteractorCollisions]: #ignoreInteractorCollisions
 [offsetObjectFollower]: #offsetObjectFollower
@@ -699,6 +735,8 @@ IProcessable
 [ResumeInteractorsCollisions(GameObject)]: #ResumeInteractorsCollisionsGameObject
 [ResumeInteractorsCollisions(InteractorFacade)]: #ResumeInteractorsCollisionsInteractorFacade
 [ResumeInteractorUngrabbedCollision(InteractableFacade)]: #ResumeInteractorUngrabbedCollisionInteractableFacade
+[SnapDependentsToSource()]: #SnapDependentsToSource
+[SnapToSource()]: #SnapToSource
 [SolveBodyCollisions()]: #SolveBodyCollisions
 [StopCheckDivergenceAtEndOfFrameRoutine()]: #StopCheckDivergenceAtEndOfFrameRoutine
 [Implements]: #Implements

--- a/Runtime/SharedResources/Scripts/PseudoBodyFacade.cs
+++ b/Runtime/SharedResources/Scripts/PseudoBodyFacade.cs
@@ -291,6 +291,14 @@
             Processor.SolveBodyCollisions();
         }
 
+        /// <summary>
+        /// Snaps the <see cref="Processor.Character"/> to the <see cref="Source"/> position.
+        /// </summary>
+        public virtual void SnapToSource()
+        {
+            Processor.SnapToSource();
+        }
+
         protected virtual void Awake()
         {
 #pragma warning disable 0618

--- a/Runtime/SharedResources/Scripts/PseudoBodyProcessor.cs
+++ b/Runtime/SharedResources/Scripts/PseudoBodyProcessor.cs
@@ -260,6 +260,18 @@
         /// The routine for checking to see if the <see cref="Facade.Source"/> is still diverged with the <see cref="Character"/> at the end of the frame.
         /// </summary>
         protected Coroutine checkDivergedAtEndOfFrameRoutine;
+        /// <summary>
+        /// Whether to snap the dependents to the <see cref="Facade.Source"/> without any divergent checking.
+        /// </summary>
+        protected bool doSnapToSource;
+
+        /// <summary>
+        /// Snaps the <see cref="Character"/> to the <see cref="Facade.Source"/> position.
+        /// </summary>
+        public virtual void SnapToSource()
+        {
+            doSnapToSource = true;
+        }
 
         /// <summary>
         /// Positions, sizes and controls all variables necessary to make a body representation follow the given <see cref="PseudoBodyFacade.Source"/>.
@@ -268,6 +280,13 @@
         {
             if (!this.IsValidState())
             {
+                return;
+            }
+
+            if (doSnapToSource)
+            {
+                SnapDependentsToSource();
+                doSnapToSource = false;
                 return;
             }
 
@@ -469,9 +488,7 @@
             ConfigureSourceObjectFollower();
             ConfigureOffsetObjectFollower();
             Interest = MovementInterest.CharacterControllerUntilAirborne;
-            MatchCharacterControllerWithSource(true);
-            MatchRigidbodyAndColliderWithCharacterController();
-            RememberCurrentPositions();
+            SnapDependentsToSource();
         }
 
         protected virtual void OnDisable()
@@ -479,6 +496,16 @@
             StopCheckDivergenceAtEndOfFrameRoutine();
             sourceObjectFollower = null;
             offsetObjectFollower = null;
+        }
+
+        /// <summary>
+        /// Snaps the <see cref="CharacterController"/> and the <see cref="PhysicsBody"/> to the <see cref="Facade.Source"/>.
+        /// </summary>
+        protected virtual void SnapDependentsToSource()
+        {
+            MatchCharacterControllerWithSource(true);
+            MatchRigidbodyAndColliderWithCharacterController();
+            RememberCurrentPositions();
         }
 
         /// <summary>


### PR DESCRIPTION
The SnapToSource method will cause the PseudoBody tracking elements
to snap to the Facade.Source without colliding with anything in its
path.