### PR TITLE
feat(Facade): add jump method to apply jump force

### DIFF
--- a/Documentation/API/PseudoBodyFacade.md
+++ b/Documentation/API/PseudoBodyFacade.md
@@ -12,6 +12,7 @@ The public interface for the PseudoBody prefab.
   * [BecameGrounded]
   * [Converged]
   * [Diverged]
+  * [Jumped]
   * [StillDiverged]
   * [WillDiverge]
 * [Properties]
@@ -35,6 +36,7 @@ The public interface for the PseudoBody prefab.
   * [ClearOffset()]
   * [ClearSource()]
   * [DoCheckWillDiverge(Vector3)]
+  * [Jump(Single)]
   * [ListenToRigidbodyMovement()]
   * [OnAfterCharacterRadiusChange()]
   * [OnAfterOffsetChange()]
@@ -104,6 +106,16 @@ Emitted when the pseudo body starts no longer being within the threshold distanc
 
 ```
 public UnityEvent Diverged
+```
+
+#### Jumped
+
+Emitted when a jump is initiated.
+
+##### Declaration
+
+```
+public UnityEvent Jumped
 ```
 
 #### StillDiverged
@@ -337,6 +349,22 @@ public virtual void DoCheckWillDiverge(Vector3 targetPosition)
 | --- | --- | --- |
 | Vector3 | targetPosition | The new position to check for. |
 
+#### Jump(Single)
+
+Adds force to the [PhysicsBody] to simulate a jump at the given force.
+
+##### Declaration
+
+```
+public virtual void Jump(float force)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | force | The force to jump by. |
+
 #### ListenToRigidbodyMovement()
 
 Sets the source of truth for movement to come from [PhysicsBody] until [Character] hits the ground, then [Character] is the new source of truth.
@@ -483,6 +511,7 @@ If body collisions should be prevented this method needs to be called right befo
 [Source]: PseudoBodyFacade.md#Source
 [Offset]: PseudoBodyFacade.md#Offset
 [Source]: PseudoBodyFacade.md#Source
+[PhysicsBody]: PseudoBodyFacade.md#PhysicsBody
 [PhysicsBody]: PseudoBodyProcessor.md#Tilia_Trackers_PseudoBody_PseudoBodyProcessor_PhysicsBody
 [Character]: PseudoBodyProcessor.md#Tilia_Trackers_PseudoBody_PseudoBodyProcessor_Character
 [Character]: PseudoBodyProcessor.md#Tilia_Trackers_PseudoBody_PseudoBodyProcessor_Character
@@ -503,6 +532,7 @@ If body collisions should be prevented this method needs to be called right befo
 [BecameGrounded]: #BecameGrounded
 [Converged]: #Converged
 [Diverged]: #Diverged
+[Jumped]: #Jumped
 [StillDiverged]: #StillDiverged
 [WillDiverge]: #WillDiverge
 [Properties]: #Properties
@@ -526,6 +556,7 @@ If body collisions should be prevented this method needs to be called right befo
 [ClearOffset()]: #ClearOffset
 [ClearSource()]: #ClearSource
 [DoCheckWillDiverge(Vector3)]: #DoCheckWillDivergeVector3
+[Jump(Single)]: #JumpSingle
 [ListenToRigidbodyMovement()]: #ListenToRigidbodyMovement
 [OnAfterCharacterRadiusChange()]: #OnAfterCharacterRadiusChange
 [OnAfterOffsetChange()]: #OnAfterOffsetChange

--- a/Documentation/API/PseudoBodyProcessor.md
+++ b/Documentation/API/PseudoBodyProcessor.md
@@ -19,10 +19,12 @@ Sets up the PseudoBody prefab based on the provided user settings and implements
   * [previousCharacterControllerPosition]
   * [previousOffsetPosition]
   * [previousRigidbodyPosition]
+  * [resetInterestAfterAddForceRoutine]
   * [restoreColliders]
   * [rigidbodySetFrameCount]
   * [smoothDampVelocity]
   * [sourceObjectFollower]
+  * [waitForEndOfFixedUpdate]
   * [wasCharacterControllerGrounded]
   * [wasDiverged]
 * [Properties]
@@ -33,13 +35,17 @@ Sets up the PseudoBody prefab based on the provided user settings and implements
   * [CollisionsToIgnore]
   * [CurrentDivergenceState]
   * [Facade]
+  * [ForceDirection]
+  * [ForceType]
   * [Interest]
   * [IsCharacterControllerGrounded]
   * [IsDiverged]
+  * [IsGrounded]
   * [PhysicsBody]
   * [RigidbodyCollider]
   * [UpdateSourcePosition]
 * [Methods]
+  * [AddForce(Single)]
   * [AddPositionMutator(GameObject)]
   * [Awake()]
   * [CheckDivergence()]
@@ -67,6 +73,7 @@ Sets up the PseudoBody prefab based on the provided user settings and implements
   * [ProcessObjectFollowers()]
   * [RememberCurrentPositions()]
   * [RemovePositionMutator(GameObject)]
+  * [ResetInterestAfterForce()]
   * [ResolveDivergence()]
   * [ResolveDivergence(Vector3)]
   * [ResumeInteractorsCollisions(GameObject)]
@@ -76,6 +83,7 @@ Sets up the PseudoBody prefab based on the provided user settings and implements
   * [SnapToSource()]
   * [SolveBodyCollisions()]
   * [StopCheckDivergenceAtEndOfFrameRoutine()]
+  * [StopResetInterestAfterForceRoutine()]
   * [TryGetMutator(GameObject, out TransformPositionMutator)]
   * [UpdateAliasForCollision()]
   * [UpdateAliasForDivergence()]
@@ -220,6 +228,16 @@ The previous position of [PhysicsBody].
 protected Vector3 previousRigidbodyPosition
 ```
 
+#### resetInterestAfterAddForceRoutine
+
+The routine for resetting the [Interest] to [RigidbodyUntilGrounded] after a force is added.
+
+##### Declaration
+
+```
+protected Coroutine resetInterestAfterAddForceRoutine
+```
+
 #### restoreColliders
 
 The colliders to restore after an ungrab.
@@ -258,6 +276,16 @@ An optional follower of [Source].
 
 ```
 protected ObjectFollower sourceObjectFollower
+```
+
+#### waitForEndOfFixedUpdate
+
+A YieldInstruction that waits for the end of the fixed update process.
+
+##### Declaration
+
+```
+protected YieldInstruction waitForEndOfFixedUpdate
 ```
 
 #### wasCharacterControllerGrounded
@@ -352,6 +380,26 @@ The public interface facade.
 public PseudoBodyFacade Facade { get; set; }
 ```
 
+#### ForceDirection
+
+The direction to apply the force to on the `AddForce` method.
+
+##### Declaration
+
+```
+public Vector3 ForceDirection { get; set; }
+```
+
+#### ForceType
+
+The ForceMode to apply the force to on the `AddForce` method.
+
+##### Declaration
+
+```
+public ForceMode ForceType { get; set; }
+```
+
 #### Interest
 
 The object that defines the main source of truth for movement.
@@ -380,6 +428,16 @@ Whether Facade.Source has diverged from the [Character].
 
 ```
 public virtual bool IsDiverged { get; protected set; }
+```
+
+#### IsGrounded
+
+Whether the PseudoBody is grounded using a detailed ground check.
+
+##### Declaration
+
+```
+public virtual bool IsGrounded { get; }
 ```
 
 #### PhysicsBody
@@ -413,6 +471,22 @@ public bool UpdateSourcePosition { get; set; }
 ```
 
 ### Methods
+
+#### AddForce(Single)
+
+Adds a force to the [PhysicsBody] in the [ForceDirection] using the [ForceType].
+
+##### Declaration
+
+```
+public virtual void AddForce(float power)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | power | The amount of force to apply in the Tilia.Trackers.PseudoBody.PseudoBodyProcessor.forceDirection. |
 
 #### AddPositionMutator(GameObject)
 
@@ -800,6 +874,22 @@ public virtual void RemovePositionMutator(GameObject mutatorContainer)
 | --- | --- | --- |
 | GameObject | mutatorContainer | The container to look for the Position Mutator in. |
 
+#### ResetInterestAfterForce()
+
+Resets the [Interest] back to [RigidbodyUntilGrounded] after a force is applied to the [PhysicsBody].
+
+##### Declaration
+
+```
+protected IEnumerator ResetInterestAfterForce()
+```
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Collections.IEnumerator | An Enumerator to manage the running of the Coroutine. |
+
 #### ResolveDivergence()
 
 Resolves any divergence between the [Character] position and the actual position of the Facade.Source and Facade.Offset.
@@ -917,6 +1007,16 @@ Stops the divergence check coroutine from running.
 
 ```
 protected virtual void StopCheckDivergenceAtEndOfFrameRoutine()
+```
+
+#### StopResetInterestAfterForceRoutine()
+
+Stops the reset interest after force coroutine from running.
+
+##### Declaration
+
+```
+protected virtual void StopResetInterestAfterForceRoutine()
 ```
 
 #### TryGetMutator(GameObject, out TransformPositionMutator)
@@ -1083,6 +1183,8 @@ IProcessable
 [Character]: PseudoBodyProcessor.md#Character
 [PhysicsBody]: PseudoBodyProcessor.md#PhysicsBody
 [Interest]: PseudoBodyProcessor.md#Interest
+[RigidbodyUntilGrounded]: PseudoBodyProcessor.MovementInterest.md#MovementInterest_RigidbodyUntilGrounded
+[Interest]: PseudoBodyProcessor.md#Interest
 [Rigidbody]: PseudoBodyProcessor.MovementInterest.md#MovementInterest_Rigidbody
 [RigidbodyUntilGrounded]: PseudoBodyProcessor.MovementInterest.md#MovementInterest_RigidbodyUntilGrounded
 [Source]: PseudoBodyFacade.md#Tilia_Trackers_PseudoBody_PseudoBodyFacade_Source
@@ -1092,6 +1194,9 @@ IProcessable
 [PseudoBodyFacade]: PseudoBodyFacade.md
 [Character]: PseudoBodyProcessor.md#Character
 [Character]: PseudoBodyProcessor.md#Character
+[PhysicsBody]: PseudoBodyProcessor.md#PhysicsBody
+[ForceDirection]: PseudoBodyProcessor.md#ForceDirection
+[ForceType]: PseudoBodyProcessor.md#ForceType
 [Character]: PseudoBodyProcessor.md#Character
 [Character]: PseudoBodyProcessor.md#Character
 [Character]: PseudoBodyProcessor.md#Character
@@ -1110,6 +1215,9 @@ IProcessable
 [Character]: PseudoBodyProcessor.md#Character
 [Interest]: PseudoBodyProcessor.md#Interest
 [Source]: PseudoBodyFacade.md#Tilia_Trackers_PseudoBody_PseudoBodyFacade_Source
+[Interest]: PseudoBodyProcessor.md#Interest
+[RigidbodyUntilGrounded]: PseudoBodyProcessor.MovementInterest.md#MovementInterest_RigidbodyUntilGrounded
+[PhysicsBody]: PseudoBodyProcessor.md#PhysicsBody
 [Character]: PseudoBodyProcessor.md#Character
 [Character]: PseudoBodyProcessor.md#Character
 [PhysicsBody]: PseudoBodyProcessor.md#PhysicsBody
@@ -1133,10 +1241,12 @@ IProcessable
 [previousCharacterControllerPosition]: #previousCharacterControllerPosition
 [previousOffsetPosition]: #previousOffsetPosition
 [previousRigidbodyPosition]: #previousRigidbodyPosition
+[resetInterestAfterAddForceRoutine]: #resetInterestAfterAddForceRoutine
 [restoreColliders]: #restoreColliders
 [rigidbodySetFrameCount]: #rigidbodySetFrameCount
 [smoothDampVelocity]: #smoothDampVelocity
 [sourceObjectFollower]: #sourceObjectFollower
+[waitForEndOfFixedUpdate]: #waitForEndOfFixedUpdate
 [wasCharacterControllerGrounded]: #wasCharacterControllerGrounded
 [wasDiverged]: #wasDiverged
 [Properties]: #Properties
@@ -1147,13 +1257,17 @@ IProcessable
 [CollisionsToIgnore]: #CollisionsToIgnore
 [CurrentDivergenceState]: #CurrentDivergenceState
 [Facade]: #Facade
+[ForceDirection]: #ForceDirection
+[ForceType]: #ForceType
 [Interest]: #Interest
 [IsCharacterControllerGrounded]: #IsCharacterControllerGrounded
 [IsDiverged]: #IsDiverged
+[IsGrounded]: #IsGrounded
 [PhysicsBody]: #PhysicsBody
 [RigidbodyCollider]: #RigidbodyCollider
 [UpdateSourcePosition]: #UpdateSourcePosition
 [Methods]: #Methods
+[AddForce(Single)]: #AddForceSingle
 [AddPositionMutator(GameObject)]: #AddPositionMutatorGameObject
 [Awake()]: #Awake
 [CheckDivergence()]: #CheckDivergence
@@ -1181,6 +1295,7 @@ IProcessable
 [ProcessObjectFollowers()]: #ProcessObjectFollowers
 [RememberCurrentPositions()]: #RememberCurrentPositions
 [RemovePositionMutator(GameObject)]: #RemovePositionMutatorGameObject
+[ResetInterestAfterForce()]: #ResetInterestAfterForce
 [ResolveDivergence()]: #ResolveDivergence
 [ResolveDivergence(Vector3)]: #ResolveDivergenceVector3
 [ResumeInteractorsCollisions(GameObject)]: #ResumeInteractorsCollisionsGameObject
@@ -1190,6 +1305,7 @@ IProcessable
 [SnapToSource()]: #SnapToSource
 [SolveBodyCollisions()]: #SolveBodyCollisions
 [StopCheckDivergenceAtEndOfFrameRoutine()]: #StopCheckDivergenceAtEndOfFrameRoutine
+[StopResetInterestAfterForceRoutine()]: #StopResetInterestAfterForceRoutine
 [TryGetMutator(GameObject, out TransformPositionMutator)]: #TryGetMutatorGameObject-out TransformPositionMutator
 [UpdateAliasForCollision()]: #UpdateAliasForCollision
 [UpdateAliasForDivergence()]: #UpdateAliasForDivergence

--- a/Runtime/Prefabs/Trackers.PseudoBody.prefab
+++ b/Runtime/Prefabs/Trackers.PseudoBody.prefab
@@ -454,6 +454,8 @@ MonoBehaviour:
   updateSourcePosition: 1
   aliasMovementDuration: 0
   collisionMovementDuration: 0
+  forceDirection: {x: 0, y: 1, z: 0}
+  forceType: 0
   character: {fileID: 883720338106885674}
   physicsBody: {fileID: 4655073129495598539}
   rigidbodyCollider: {fileID: 1290236144137004063}

--- a/Runtime/SharedResources/Scripts/PseudoBodyFacade.cs
+++ b/Runtime/SharedResources/Scripts/PseudoBodyFacade.cs
@@ -203,6 +203,10 @@
         /// Emitted when the body stops touching ground.
         /// </summary>
         public UnityEvent BecameAirborne = new UnityEvent();
+        /// <summary>
+        /// Emitted when a jump is initiated.
+        /// </summary>
+        public UnityEvent Jumped = new UnityEvent();
         #endregion
 
         #region Reference Settings
@@ -387,6 +391,26 @@
         public virtual void ResolveDivergence()
         {
             Processor.ResolveDivergence();
+        }
+
+        /// <summary>
+        /// Adds force to the <see cref="PhysicsBody"/> to simulate a jump at the given force.
+        /// </summary>
+        /// <param name="force">The force to jump by.</param>
+        public virtual void Jump(float force)
+        {
+            if (!Processor.IsGrounded)
+            {
+                return;
+            }
+
+            if(Processor.IsDiverged)
+            {
+                Debug.Log("wee");
+            }
+
+            Processor.AddForce(force);
+            Jumped?.Invoke();
         }
 
         protected virtual void Awake()


### PR DESCRIPTION
A new `Jump(force)` method has been added to the Facade that calls a new internal `AddForce(force)` method on the Processor which will add a force to the PhysicsBody (Rigidbody).

A new Jumped event has been added as well that is emitted when the `Jump` method is called.