### PR TITLE
fix(PseudoBodyProcessor): use offset local position for diverge test - fixes #276

### DIFF
--- a/Runtime/SharedResources/Scripts/PseudoBodyProcessor.cs
+++ b/Runtime/SharedResources/Scripts/PseudoBodyProcessor.cs
@@ -444,7 +444,7 @@
         /// <returns>Whether a divergence will occur.</returns>
         public virtual bool CheckWillDiverge(Vector3 targetPosition)
         {
-            Vector3 difference = targetPosition - Facade.Offset.transform.position;
+            Vector3 difference = targetPosition - Facade.Offset.transform.localPosition;
             Vector3 position = GetCharacterPosition(Facade.Source.transform.position + difference, out float _);
             Vector3 movement = position - Character.transform.position;
             Character.Move(movement);


### PR DESCRIPTION
The CheckWillDiverge method was using the offset absolute position to calculate the offset whereas it should be using the local position as the absolute position may already be offset if the TrackedAlias position is changed to anything other than `0,0,0` which would cause the character movement to be much higher than it needed to be.